### PR TITLE
Tasks Module - date format in response issue, fixed

### DIFF
--- a/src/helpers/taskMapper.js
+++ b/src/helpers/taskMapper.js
@@ -4,7 +4,10 @@ const prepareTaskTypeObject = (task) => {
   return {
     ...task._doc,
     id: task._id.toString(),
-    date: task._doc.date.toISOString(),
+    date:
+      task._doc.type === "year"
+        ? task._doc.date.getFullYear()
+        : task._doc.date.toISOString(),
     createdAt: task._doc.createdAt.toISOString(),
     updatedAt: task._doc.updatedAt.toISOString(),
     priority: task.priority,


### PR DESCRIPTION
- Modify taskMapper.js to return the date in the format "YYYY" for year tasks